### PR TITLE
Fix typo in comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
                 const subfieldString = subfields.map(sf => `$$${sf.code}${sf.value}`).join('');
                 const ruleName = `add ${fieldNumber}_${ind1}${ind2}${subfieldString}`;
 
-                // Falls kein Erweiterungsname eingegeben wurde, verwenden wir den Regellnamen
+                // Falls kein Erweiterungsname eingegeben wurde, verwenden wir den Regelnamen
                 if (!extensionName) {
                     extensionName = ruleName;
                 }


### PR DESCRIPTION
## Summary
- fix typo "Regellnamen" -> "Regelnamen" in `index.html`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68419a6b29e48324acad5638204f9529