### PR TITLE
Add parseSubfields module and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Aus diesen Eingaben wird ein JSON-Objekt generiert, welches als Vorlage für MAR
 4. Nutzen Sie den **"In Zwischenablage speichern"**-Button, um die generierte Erweiterung zu kopieren.
 5. Mit **"Neue Erweiterung erstellen"** setzen Sie das Formular zurück, um eine weitere Erweiterung anzulegen.
 
+## Tests
+
+Um die automatischen Tests auszuführen, wird Node.js benötigt.
+Im Verzeichnis `tests` befindet sich ein einfaches Testskript. Die Tests starten Sie mit:
+
+```
+node tests/run-tests.js
+```
+
 ## Anpassungen und Erweiterungen
 
 - Die CSS-Variablen im `:root`-Block ermöglichen schnelle Farbanpassungen.

--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
         <pre id="fullFieldPreview" aria-live="polite"></pre>
     </div>
 
+    <script src="parseSubfields.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const marcForm = document.getElementById('marcForm');
@@ -192,27 +193,6 @@
                 }, 3000);
             }
 
-            // Diese Funktion zerlegt den eingegebenen String in Unterfelder
-            function parseSubfields(input) {
-                const subfields = [];
-                input = input.trim();
-                // Falls der Input mit "$$" beginnt, entfernen wir diesen Teil
-                if (input.startsWith('$$')) {
-                    input = input.substring(2);
-                }
-                // Zerlegen an den "$$" Trennzeichen
-                const parts = input.split('$$');
-                parts.forEach(part => {
-                    part = part.trim();
-                    // Nur gültige Unterfelder (mind. Code + Wert) übernehmen
-                    if (part.length > 1) {
-                        const code = part.charAt(0);
-                        const value = part.substring(1).trim();
-                        subfields.push({ code, value });
-                    }
-                });
-                return subfields;
-            }
 
             function generateExtension() {
                 const fieldNumber = marcForm.fieldNumber.value.trim();

--- a/parseSubfields.js
+++ b/parseSubfields.js
@@ -1,0 +1,25 @@
+(function (global) {
+  function parseSubfields(input) {
+    const subfields = [];
+    input = input.trim();
+    if (input.startsWith('$$')) {
+      input = input.substring(2);
+    }
+    const parts = input.split('$$');
+    parts.forEach(part => {
+      part = part.trim();
+      if (part.length > 1) {
+        const code = part.charAt(0);
+        const value = part.substring(1).trim();
+        subfields.push({ code, value });
+      }
+    });
+    return subfields;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = parseSubfields;
+  } else {
+    global.parseSubfields = parseSubfields;
+  }
+})(this);

--- a/tests/parseSubfields.test.js
+++ b/tests/parseSubfields.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const parseSubfields = require('../parseSubfields');
+
+// Test 1: simple parsing
+assert.deepStrictEqual(
+  parseSubfields('$$afoo$$2bar'),
+  [
+    { code: 'a', value: 'foo' },
+    { code: '2', value: 'bar' }
+  ]
+);
+
+// Test 2: spaces and trimming
+assert.deepStrictEqual(
+  parseSubfields('  $$a foo  $$b bar  '),
+  [
+    { code: 'a', value: 'foo' },
+    { code: 'b', value: 'bar' }
+  ]
+);
+
+// Test 3: invalid subfield (missing value)
+assert.deepStrictEqual(parseSubfields('$$a'), []);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const testsDir = __dirname;
+
+const files = fs.readdirSync(testsDir).filter(f => f.endsWith('.test.js'));
+let failures = 0;
+
+files.forEach(file => {
+  try {
+    require(path.join(testsDir, file));
+    console.log(`✓ ${file}`);
+  } catch (err) {
+    failures++;
+    console.error(`✗ ${file}`);
+    console.error(err);
+  }
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log('\nAll tests passed');
+}


### PR DESCRIPTION
## Summary
- extract `parseSubfields` into its own module so it can be reused
- include the new script from `index.html`
- add a lightweight Node test runner and tests for `parseSubfields`
- document how to run the tests

## Testing
- `node tests/run-tests.js`


------
https://chatgpt.com/codex/tasks/task_e_68419ce3c0648324ae5410b341e7aa88